### PR TITLE
API fallback проверки ссылок и команда в уведомлениях

### DIFF
--- a/tc_link_manager/config.php
+++ b/tc_link_manager/config.php
@@ -7,4 +7,8 @@ return [
         'thread_id_new_links' => '',
         'thread_id_broken_links' => ''
     ],
+    'api' => [
+        'check-aff-link' => '',
+        'manager_token' => ''
+    ]
 ];


### PR DESCRIPTION

- Добавлена дополнительная проверка ссылок через API при ошибке wp_remote_head
- Добавлен метод api_link_check() для fallback проверки через внешний API
- Добавлена автоматическая установка https:// для URL без протокола
- Добавлен запрос к менеджеру для получения названия команды
- Обновлены уведомления: теперь показывают "domain.com (Команда X)"
- Улучшена надежность проверки партнерских ссылок